### PR TITLE
Add support for time intervals in race results

### DIFF
--- a/ergast_py/models/time.py
+++ b/ergast_py/models/time.py
@@ -1,0 +1,28 @@
+""" Time class """
+
+import datetime
+from dataclasses import dataclass
+
+
+@dataclass
+class Time:
+    """
+    Representation of a Formula One Team
+
+    Time may contain:
+        millis: datetime.time
+        time: String
+    """
+
+    def __init__(self, millis: datetime.time, time: str) -> None:
+        self.millis = millis
+        self.time = time
+
+    def __repr__(self) -> str:
+        members = ", ".join(f"{key}={value}" for key, value in self.__dict__.items())
+        return f"{type(self).__name__}({members})"
+
+    def __eq__(self, __o: object) -> bool:
+        return isinstance(__o, Time) and (
+            self.millis == __o.millis and self.time == __o.time
+        )

--- a/ergast_py/type_constructor.py
+++ b/ergast_py/type_constructor.py
@@ -19,6 +19,7 @@ from ergast_py.models.season import Season
 from ergast_py.models.standings_list import StandingsList
 from ergast_py.models.status import Status
 from ergast_py.models.timing import Timing
+from ergast_py.models.time import Time
 
 
 #pylint: disable=too-many-public-methods
@@ -199,6 +200,18 @@ class TypeConstructor():
         """
         return [self.construct_race(race) for race in races]
 
+    def construct_time(self, time: dict) -> Time:
+        """
+        Construct a Time from a JSON dictionary
+        """
+        if time != {}:
+            return Time(
+                millis=Helpers().construct_lap_time_millis(millis=time),
+                time=time["time"]
+            )
+        else:
+            return Time(millis=None, time=None)
+
     def construct_result(self, result: dict) -> Result:
         """
         Construct a Result from a JSON dictionary
@@ -214,7 +227,7 @@ class TypeConstructor():
             grid=int(result["grid"]),
             laps=int(result["laps"]),
             status=int(StatusType().string_to_id[result["status"]]),
-            time=Helpers().construct_lap_time_millis(millis=result["Time"]),
+            time=self.construct_time(result["Time"]),
             fastest_lap=self.construct_fastest_lap(result["FastestLap"]),
             qual_1=Helpers().format_lap_time(time=result["Q1"]),
             qual_2=Helpers().format_lap_time(time=result["Q2"]),

--- a/tests/test_type_constructor.py
+++ b/tests/test_type_constructor.py
@@ -18,6 +18,7 @@ from ergast_py.models.season import Season
 from ergast_py.models.standings_list import StandingsList
 from ergast_py.models.status import Status
 from ergast_py.models.timing import Timing
+from ergast_py.models.time import Time
 from ergast_py.requester import Requester
 from ergast_py.type_constructor import TypeConstructor
 
@@ -178,10 +179,11 @@ class TestTypeConstructor():
                                   url="http://en.wikipedia.org/wiki/Scuderia_Ferrari",
                                   name="Ferrari", nationality="Italian")
 
+        time = Time(millis=datetime.time(20, 37, 33, 584000), time="1:37:33.584")
+
         expected = [Result(number=16, position=1, position_text="1", points=26, driver=driver,
                            constructor=constructor, grid=1, laps=57, status=1,
-                           time=datetime.time(hour=1, minute=37, second=33, microsecond=584000),
-                           fastest_lap=fastest_lap, qual_1=None, qual_2=None, qual_3=None)]
+                           time=time, fastest_lap=fastest_lap, qual_1=None, qual_2=None, qual_3=None)]
 
         assert expected == self.t.construct_results(params)
 


### PR DESCRIPTION
Earlier `Result` class was giving `millis` as the time for a driver. In this PR, I added support for time interval as well. So, both values will come in the form of Time object. Here is a sample json depicting the `Time` object from `http://ergast.com/api/f1/current/last/results.json`

```
"Time": {
    "millis": "5648723",
    "time": "+11.987"
},
```

I created a new `Time` data class for this json object and use that in construct_result function.
I modified the tests as well to include this change.