### PR TITLE
Add support for time interval in race result

### DIFF
--- a/ergast_py/__init__.py
+++ b/ergast_py/__init__.py
@@ -42,6 +42,7 @@ from ergast_py.models.season import Season
 from ergast_py.models.standings_list import StandingsList
 from ergast_py.models.status import Status
 from ergast_py.models.timing import Timing
+from ergast_py.models.time import Time
 
 __version__ = "0.7.0"
 
@@ -64,4 +65,5 @@ __all__ = [
     "StandingsList",
     "Status",
     "Timing",
+    "Time"
 ]

--- a/ergast_py/constants/expected.py
+++ b/ergast_py/constants/expected.py
@@ -223,3 +223,13 @@ class Expected:
             "DriverStandings": "dict",
             "ConstructorStandings": "dict",
         }
+    
+    @property
+    def time(self):
+        """
+        Return the expected types of a Time
+        """
+        return {
+            "millis": "datetime.time",
+            "time": "string",
+        }

--- a/ergast_py/models/time.py
+++ b/ergast_py/models/time.py
@@ -1,0 +1,19 @@
+""" Time class """
+import datetime
+from dataclasses import dataclass
+
+from ergast_py.models.base_model import BaseModel
+
+
+@dataclass
+class Time(BaseModel):
+    """
+    Representation of a Finishing Time in a Race for a Formula One Driver
+
+    Time may contain:
+        millis: datetime.time
+        time: String
+    """
+
+    millis: datetime.time
+    time: str

--- a/ergast_py/type_constructor.py
+++ b/ergast_py/type_constructor.py
@@ -107,6 +107,9 @@ class TypeConstructor:
         return self._populate_missing(
             expected=Expected().standings_list, actual=standings_list
         )
+    
+    def _populate_missing_time(self, time: dict) -> dict:
+        return self._populate_missing(expected=Expected().time, actual=time)
 
     #
     #   PUBLIC METHODS
@@ -229,6 +232,8 @@ class TypeConstructor:
         """
         Construct a Time object from a JSON dictionary
         """
+        time = self._populate_missing_time(time)
+        
         try:
             millis = Helpers().construct_lap_time_millis(millis=time)
         except ValueError:

--- a/ergast_py/type_constructor.py
+++ b/ergast_py/type_constructor.py
@@ -18,6 +18,7 @@ from ergast_py.models.season import Season
 from ergast_py.models.standings_list import StandingsList
 from ergast_py.models.status import Status
 from ergast_py.models.timing import Timing
+from ergast_py.models.time import Time
 
 
 # pylint: disable=too-many-public-methods
@@ -224,6 +225,16 @@ class TypeConstructor:
             laps=self.construct_laps(race["Laps"]),
         )
 
+    def construct_time(self, time: dict) -> Time:
+        """
+        Construct a Time object from a JSON dictionary
+        """
+        try:
+            millis = Helpers().construct_lap_time_millis(millis=time)
+        except ValueError:
+            millis = None
+        return Time(millis=millis, time=time["time"])
+
     def construct_races(self, races: dict) -> list[Race]:
         """
         Construct a list of Races from a JSON dictionary
@@ -244,12 +255,6 @@ class TypeConstructor:
                 # Warn that the value isn't present
                 continue
 
-        try:
-            time = Helpers().construct_lap_time_millis(millis=result["Time"])
-        except ValueError:
-            # Warn that the value isn't present
-            time = None
-
         return Result(
             number=int(result["number"]),
             position=int(result["position"]),
@@ -260,7 +265,7 @@ class TypeConstructor:
             grid=int(result["grid"]),
             laps=int(result["laps"]),
             status=int(StatusType().string_to_id[result["status"]]),
-            time=time,
+            time=self.construct_time(result["Time"]),
             fastest_lap=self.construct_fastest_lap(result["FastestLap"]),
             qual_1=qualifying["Q1"],
             qual_2=qualifying["Q2"],

--- a/tests/test_type_constructor.py
+++ b/tests/test_type_constructor.py
@@ -19,6 +19,7 @@ from ergast_py.models.status import Status
 from ergast_py.models.timing import Timing
 from ergast_py.requester import Requester
 from ergast_py.type_constructor import TypeConstructor
+from ergast_py.models.time import Time
 from tests import constants
 
 
@@ -206,7 +207,12 @@ class TestTypeConstructor:
                 grid=1,
                 laps=57,
                 status=1,
-                time=datetime.time(hour=1, minute=37, second=33, microsecond=584000),
+                time=Time(
+                    millis=datetime.time(
+                        hour=1, minute=37, second=33, microsecond=584000
+                    ),
+                    time="1:37:33.584",
+                ),
                 fastest_lap=fastest_lap,
                 qual_1=None,
                 qual_2=None,

--- a/tests/test_type_constructor.py
+++ b/tests/test_type_constructor.py
@@ -148,6 +148,17 @@ class TestTypeConstructor:
         ]
 
         assert expected == self.t.construct_races(params)
+    
+    def test_construct_time(self):
+        """Assert construct_time function works"""
+        params = {"millis": "5853584", "time": "1:37:33.584"}
+        
+        expected = Time(
+            millis=datetime.time(hour=1, minute=37, second=33, microsecond=584000),
+            time="1:37:33.584",
+        )
+        
+        assert expected == self.t.construct_time(params)
 
     def test_construct_results(self):
         """Assert construct_results function works"""


### PR DESCRIPTION
This PR is in relation to https://github.com/Samuel-Roach/ergast-py/pull/19. I closed the previous one because that was forked from master branch. 

This is forked off `develop` and I have taken into account the comments that were in the https://github.com/Samuel-Roach/ergast-py/pull/19. 

Take a look at the source code and let me know if there are any changes to be made. Tests were ran and all were successful.